### PR TITLE
Improve Serbian Latin to Serbian Cyrillic transliteration

### DIFF
--- a/components/inheritors/SerbianLatinToCyrillicTranslationsInheritor.php
+++ b/components/inheritors/SerbianLatinToCyrillicTranslationsInheritor.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace app\components\inheritors;
 
-use Turanjanin\SerbianTransliterator\Transliterator;
+use app\helpers\SerbianTransliterator;
 use function str_starts_with;
 
 /**
@@ -31,6 +31,6 @@ class SerbianLatinToCyrillicTranslationsInheritor extends TranslationsInheritor 
 			return $translation;
 		}
 
-		return Transliterator::toCyrillic($translation);
+		return SerbianTransliterator::toCyrillic($translation);
 	}
 }

--- a/helpers/SerbianTransliterator.php
+++ b/helpers/SerbianTransliterator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace app\helpers;
+
+use Turanjanin\SerbianTransliterator\Transliterator;
+use function preg_split;
+use function str_starts_with;
+use function str_ends_with;
+
+class SerbianTransliterator extends Transliterator
+{
+    public static function toCyrillic(string $text): string
+    {
+        $text = static::normalizeLatin($text);
+
+        $whiteSpace = '(?>\s+)';
+        $html = '<[^>]+>';
+        $icuPluralMessages = '\{(?:[^{}]+|(?R))*\}';
+
+        $icuPluralParts = '(?P<selector>=\d+|zero|one|two|few|many|other)
+            \s*
+            \{
+                (?P<message>
+                    (?:
+                        [^{}]+
+                        |
+                        \{ (?&message) \}
+                    )*
+                )
+            \}';
+
+        $tokens = preg_split("#({$whiteSpace}|{$html}|{$icuPluralMessages})#u", $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        $transliterated = [];
+        foreach ($tokens as $token) {
+            $token = preg_replace_callback("#{$icuPluralParts}#xu", function ($matches) {
+                return str_replace($matches['message'], static::toCyrillic($matches['message']), $matches[0]);
+            }, $token);
+
+            if (static::shouldBeIgnored($token)) {
+                $transliterated[] = $token;
+                continue;
+            }
+
+            $transliterated[] = static::wordToCyrillic($token);
+        }
+
+        return implode('', $transliterated);
+    }
+
+    private static function shouldBeIgnored(string $token): bool
+    {
+        // HTML tags
+        if (str_starts_with($token, '<') && str_ends_with($token, '>')) {
+            return true;
+        }
+
+        // Placeholders
+        if (str_starts_with($token, '{') && str_ends_with($token, '}')) {
+            return true;
+        }
+
+        // Validation attributes
+        if (str_starts_with($token, ':')) {
+            return true;
+        }
+
+        return static::looksLikeForeignWord($token);
+    }
+}


### PR DESCRIPTION
This PR extends the Serbian transliterator so it:
- skips HTML tags,
- skips placeholders,
- properly parses ICU plural messages, even with included placeholders or HTML tags. 

I've placed the extended class in the `app\helpers` namespace. Feel free to suggest a new location as you see fit.